### PR TITLE
fix: container build on push requires lowercase repo name

### DIFF
--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           script: |
             const raw_tags_input = process.env.TAGS;
-            const image_name = process.env.IMAGE_NAME;
+            const image_name = process.env.IMAGE_NAME.toLowerCase();
             
             const tags = raw_tags_input.split(',').map(x => x.trim());
             const docker_tags = tags.map(x => `${image_name}:${x}`).join(',');

--- a/Dockerfile.cloudrun
+++ b/Dockerfile.cloudrun
@@ -1,3 +1,3 @@
-FROM ghcr.io/Open-Paws/label-studio:latest
+FROM ghcr.io/open-paws/label-studio:latest
 ENV LABEL_STUDIO_ONE_CLICK_DEPLOY=1 \
     STORAGE_PERSISTENCE=1


### PR DESCRIPTION
Fixes this error:
![image](https://github.com/pbanuru/Open-Paws-Label-Studio/assets/55062649/7d681c78-a378-429e-83f8-1e30d535b2b3)